### PR TITLE
[FEAT] 쿠폰 발급용 회원정보 조회 API 수정

### DIFF
--- a/src/main/java/com/lotte/danuri/auth/AuthRepository.java
+++ b/src/main/java/com/lotte/danuri/auth/AuthRepository.java
@@ -12,5 +12,5 @@ public interface AuthRepository extends JpaRepository<Auth, Long> {
 
     Optional<Auth> findByMemberIdAndDeletedDateIsNull(Long memberId);
 
-    Optional<List<Auth>> findByNameAndDeletedDateIsNull(String name);
+    Optional<List<Auth>> findByNameAndRoleAndDeletedDateIsNull(String name, int role);
 }

--- a/src/main/java/com/lotte/danuri/auth/AuthServiceImpl.java
+++ b/src/main/java/com/lotte/danuri/auth/AuthServiceImpl.java
@@ -142,7 +142,7 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public List<MemberInfoDto> getMembersInfo(String name) {
-        List<Auth> authList = authRepository.findByNameAndDeletedDateIsNull(name).orElseGet(ArrayList::new);
+        List<Auth> authList = authRepository.findByNameAndRoleAndDeletedDateIsNull(name, 0).orElseGet(ArrayList::new);
 
         return authList.stream().map(auth -> MemberInfoDto.builder()
                                         .id(auth.getId())


### PR DESCRIPTION
[작업 내용]
* 셀러가 쿠폰 발급위해 회원정보를 조회했을 때 셀러 권한이 아닌 일반 회원 목록만 조회할 수 있도록 role 조건 추가하여 수정 구현